### PR TITLE
Add config example file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 /.ts-node
 /logs
+
+config.json

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,5 @@
+{
+  "port": 1883,
+  "username": "your-username",
+  "password": "your-password"
+}


### PR DESCRIPTION
This PR adds a sample config and adds `config.json` to the `.gitignore`.

This is mostly for ease-of-development.