### PR TITLE
Allow multiple platforms to use docker image

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -38,6 +38,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR sets a `platform` variable in GitHub Action config for Docker image deployment.
This allows people to use Docker image in arm-based system (like Asahi Linux), in addition to the amd-based system.