### PR TITLE
Add Home Assistant addon feature

### DIFF
--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -24,7 +24,8 @@ jobs:
         run: |
           rsync -a . ./ha_addon/src/ --exclude './ha_addon/'
           app_version=$(cat ./ha_addon/src/package.json | jq -r '.version')
-          sed -i -e "s/_____APP_VERSION_____/${app_version}/" ./ha_addon/config.yaml
+          yq -i ".version = \"${app_version}\"" ./ha_addon/config.yaml
+          yq -i ".image = \"ghcr.io/${{ github.actor }}/echonetlite2mqtt-addon/{arch}\"" ./ha_addon/config.yaml
           echo "app_version=${app_version}" >> "$GITHUB_OUTPUT" 
       - name: Publish
         uses: home-assistant/builder@master

--- a/.github/workflows/build_addon.yml
+++ b/.github/workflows/build_addon.yml
@@ -1,0 +1,58 @@
+name: Build and Publish HA Addon
+
+on: [ workflow_dispatch ]
+#on: [push, pull_request]
+
+jobs:
+  build:
+    name: Publish
+    permissions:
+      contents: write
+      packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Copy files and modify version
+        id: version
+        run: |
+          rsync -a . ./ha_addon/src/ --exclude './ha_addon/'
+          app_version=$(cat ./ha_addon/src/package.json | jq -r '.version')
+          sed -i -e "s/_____APP_VERSION_____/${app_version}/" ./ha_addon/config.yaml
+          echo "app_version=${app_version}" >> "$GITHUB_OUTPUT" 
+      - name: Publish
+        uses: home-assistant/builder@master
+        with:
+          args: |
+            --all \
+            --addon \
+            --docker-hub ghcr.io/${{ github.actor }} \
+            --image echonetlite2mqtt-addon/{arch} \
+            --target /data/ha_addon \
+      - name: Generate GitHub Apps token
+        id: gentoken
+        uses: tibdex/github-app-token@v1
+        with:
+            app_id: ${{ secrets.HA_ADDON_APP_ID }}
+            private_key: ${{ secrets.HA_ADDON_PRIVATE_KEY }}
+      - name: Checkout HA addon repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ steps.gentoken.outputs.token }}
+          repository: ${{ github.actor }}/home-assistant-addons
+          path: addon_repos
+      - name: update config.yaml at the HA addon repo
+        working-directory: addon_repos
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          cp ../ha_addon/config.yaml echonetlite2mqtt/config.yaml
+          git add echonetlite2mqtt/config.yaml
+          git commit -m "commit for ${{steps.version.outputs.app_version}}"
+          git push origin main

--- a/ha_addon/Dockerfile
+++ b/ha_addon/Dockerfile
@@ -1,0 +1,39 @@
+ARG BUILD_FROM
+FROM ${BUILD_FROM} AS base
+
+RUN apk add --no-cache nodejs npm
+
+
+FROM base as build
+
+WORKDIR /app
+COPY ./src/package*.json ./
+RUN npm ci
+
+WORKDIR /app
+COPY ./src .
+RUN npm run build
+
+
+FROM base AS runtime
+
+# RUN apk --no-cache -U upgrade
+RUN mkdir -p /app/.ts-node
+WORKDIR /app
+
+COPY ./src/package*json ./
+#USER node
+
+RUN npm ci --omit-dev
+COPY --chown=node:node --from=build /app/MRA_V1.1.1 ./MRA_V1.1.1
+COPY --chown=node:node --from=build /app/MRA_custom ./MRA_custom
+COPY --chown=node:node --from=build /app/views ./views
+COPY --chown=node:node --from=build /app/public ./public
+COPY --chown=node:node --from=build /app/.ts-node ./.ts-node
+COPY --chown=node:node --from=build /app/LICENSE /app/buildinfo* ./
+
+EXPOSE 3000
+
+COPY docker-entrypoint.sh /
+RUN chmod a+x /docker-entrypoint.sh
+CMD /docker-entrypoint.sh

--- a/ha_addon/build.yaml
+++ b/ha_addon/build.yaml
@@ -1,0 +1,3 @@
+build_from:
+  aarch64: ghcr.io/hassio-addons/base:17.2.1
+  amd64: ghcr.io/hassio-addons/base:17.2.1

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -5,7 +5,7 @@ slug: "echonetlite2mqtt"
 arch:
   - aarch64
   - amd64
-image: ghcr.io/yymyo1/echonetlite2mqtt-addon/{arch}
+image: _____APP_IMAGE_____
 init: false
 host_network: true
 services:

--- a/ha_addon/config.yaml
+++ b/ha_addon/config.yaml
@@ -1,0 +1,45 @@
+name: "ECHONETLite2MQTT"
+description: "ECHONET Lite to MQTT bridge."
+version: "_____APP_VERSION_____"
+slug: "echonetlite2mqtt"
+arch:
+  - aarch64
+  - amd64
+image: ghcr.io/yymyo1/echonetlite2mqtt-addon/{arch}
+init: false
+host_network: true
+services:
+  - mqtt:need
+ingress: true
+ingress_port: 8099
+ports:
+  8099/tcp: 8099
+ports_description:
+  8099/tcp: "Frontend tcp-listen port"
+map:
+  - path: "/config"
+    type: homeassistant_config
+    read_only: true
+options:
+  mqtt: {}
+  REST_API_PORT: 8099
+schema:
+  mqtt:
+    host: str?
+    port: int?
+    username: str?
+    password: str?
+    ssl: bool?
+  MQTT_CA_FILE: str?
+  MQTT_CERT_FILE: str?
+  MQTT_KEY_FILE: str?
+  MQTT_BASE_TOPIC: str?
+  REST_API_HOST: str?
+  REST_API_PORT: int?
+  ECHONET_TARGET_NETWORK: str?
+  ECHONET_DEVICE_IP_LIST: str?
+  ECHONET_COMMAND_TIMEOUT: int?
+  ECHONET_DISABLE_AUTO_DEVICE_DISCOVERY: str?
+  ECHONET_ALIAS_FILE: str?
+  ECHONET_LEGACY_MULTI_NIC_MODE: str?
+  ECHONET_UNKNOWN_AS_ERROR: str?

--- a/ha_addon/docker-entrypoint.sh
+++ b/ha_addon/docker-entrypoint.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/with-contenv bashio
+
+export MQTT_OPTION_FILE=/localconfig/echonetlite2mqtt/config.json
+
+declare MQTT_PREFIX
+declare MQTT_HOST
+declare MQTT_PORT
+declare MQTT_USERNAME
+declare MQTT_PASSWORD
+declare MQTT_BROKER
+
+if ! bashio::services.available "mqtt"; then
+    bashio::log.error "No internal MQTT service found"
+else
+    bashio::log.info "MQTT service found, fetching credentials ..."
+    if bashio::var.true "$(bashio::services 'mqtt' 'ssl')"; then
+      MQTT_PREFIX="mqtts://";
+    else
+      MQTT_PREFIX="mqtt://";
+    fi
+    MQTT_HOST=$(bashio::services mqtt "host")
+    MQTT_PORT=$(bashio::services mqtt "port")
+    MQTT_USERNAME=$(bashio::services mqtt "username")
+    MQTT_PASSWORD=$(bashio::services mqtt "password")
+fi
+
+if (! bashio::config.is_empty 'mqtt'); then
+  if (bashio::config.true 'mqtt.ssl'); then
+    MQTT_PREFIX="mqtts://";
+  else
+    MQTT_PREFIX="mqtt://";
+  fi
+  if (bashio::config.has_value 'mqtt.host'); then
+    MQTT_HOST=$(bashio::config "mqtt.host")
+  fi
+  if (bashio::config.has_value 'mqtt.port'); then
+    MQTT_PORT=$(bashio::config "mqtt.port")
+  fi
+  if (bashio::config.has_value 'mqtt.username'); then
+    MQTT_USERNAME=$(bashio::config "mqtt.username")
+  fi
+  if (bashio::config.has_value 'mqtt.password'); then
+    MQTT_PASSWORD=$(bashio::config "mqtt.password")
+  fi
+fi
+
+if (bashio::config.has_value 'MQTT_CA_FILE'); then
+  export MQTT_CA_FILE=$(bashio::config "MQTT_CA_FILE")
+fi
+if (bashio::config.has_value 'MQTT_CERT_FILE'); then
+  export MQTT_CERT_FILE=$(bashio::config "MQTT_CERT_FILE")
+fi
+if (bashio::config.has_value 'MQTT_KEY_FILE'); then
+  export MQTT_KEY_FILE=$(bashio::config "MQTT_KEY_FILE")
+fi
+if (bashio::config.has_value 'MQTT_BASE_TOPIC'); then
+  export MQTT_BASE_TOPIC=$(bashio::config "MQTT_BASE_TOPIC")
+fi
+if (bashio::config.has_value 'REST_API_HOST'); then
+  export REST_API_HOST=$(bashio::config "REST_API_HOST")
+fi
+if (bashio::config.has_value 'REST_API_PORT'); then
+  export REST_API_PORT=$(bashio::config "REST_API_PORT")
+fi
+if (bashio::config.has_value 'ECHONET_TARGET_NETWORK'); then
+  export ECHONET_TARGET_NETWORK=$(bashio::config "ECHONET_TARGET_NETWORK")
+fi
+if (bashio::config.has_value 'ECHONET_DEVICE_IP_LIST'); then
+  export ECHONET_DEVICE_IP_LIST=$(bashio::config "ECHONET_DEVICE_IP_LIST")
+fi
+if (bashio::config.has_value 'ECHONET_COMMAND_TIMEOUT'); then
+  export ECHONET_COMMAND_TIMEOUT=$(bashio::config "ECHONET_COMMAND_TIMEOUT")
+fi
+if (bashio::config.has_value 'ECHONET_DISABLE_AUTO_DEVICE_DISCOVERY'); then
+  export ECHONET_DISABLE_AUTO_DEVICE_DISCOVERY=$(bashio::config "ECHONET_DISABLE_AUTO_DEVICE_DISCOVERY")
+fi
+if (bashio::config.has_value 'ECHONET_ALIAS_FILE'); then
+  export ECHONET_ALIAS_FILE=$(bashio::config "ECHONET_ALIAS_FILE")
+fi
+if (bashio::config.has_value 'ECHONET_LEGACY_MULTI_NIC_MODE'); then
+  export ECHONET_LEGACY_MULTI_NIC_MODE=$(bashio::config "ECHONET_LEGACY_MULTI_NIC_MODE")
+fi
+if (bashio::config.has_value 'ECHONET_UNKNOWN_AS_ERROR'); then
+  export ECHONET_UNKNOWN_AS_ERROR=$(bashio::config "ECHONET_UNKNOWN_AS_ERROR")
+fi
+
+export MQTT_BROKER="${MQTT_PREFIX}${MQTT_HOST}:${MQTT_PORT}";
+bashio::log.info "MQTT_BROKER=$MQTT_BROKER"
+bashio::log.info "MQTT_USRNAME=$MQTT_USERNAME"
+
+mkdir -p `dirname $MQTT_OPTION_FILE`
+
+cat << EOD > $MQTT_OPTION_FILE
+{
+  "port": ${MQTT_PORT},
+  "username": "${MQTT_USERNAME}",
+  "password": "${MQTT_PASSWORD}"
+}
+EOD
+
+INGRESS_URL=$(bashio::addon.ingress_url)
+INGRESS_ENTRY=$(bashio::addon.ingress_entry)
+export REST_API_ROOT=$INGRESS_ENTRY
+bashio::log.info "REST_API_ROOT=$REST_API_ROOT"
+
+npm run start:built

--- a/server/index.ts
+++ b/server/index.ts
@@ -24,6 +24,7 @@ interface InputParameters{
   debugLog:boolean;
   restApiPort:number;
   restApiHost:string;
+  restApiRoot:string;
   mqttBroker:string;
   mqttOptionFile:string;
   mqttBaseTopic:string;
@@ -44,6 +45,7 @@ let echonetCommandTimeout = 3000;
 let debugLog = false;
 let restApiPort = 3000;
 let restApiHost = "0.0.0.0";
+let restApiRoot = "";
 let mqttBroker = "";
 let mqttOptionFile = "";
 let mqttBaseTopic = "echonetlite2mqtt/elapi/v2/devices";
@@ -132,6 +134,10 @@ if("REST_API_PORT" in process.env && process.env.REST_API_PORT !== undefined)
 if("REST_API_HOST" in process.env && process.env.REST_API_HOST !== undefined)
 {
   restApiHost = process.env.REST_API_HOST.replace(/^"/g, "").replace(/"$/g, "");
+}
+if("REST_API_ROOT" in process.env && process.env.REST_API_ROOT !== undefined)
+{
+  restApiRoot = process.env.REST_API_ROOT.replace(/^"/g, "").replace(/"$/g, "");
 }
 if("MQTT_BROKER" in process.env && process.env.MQTT_BROKER !== undefined)
 {
@@ -234,6 +240,13 @@ for(var i = 2;i < process.argv.length; i++){
       restApiHost = value.replace(/^"/g, "").replace(/"$/g, "");
     }
   }
+  if(name === "--RestApiRoot".toLowerCase())
+  {
+    if(value!=="")
+    {
+      restApiRoot = value.replace(/^"/g, "").replace(/"$/g, "");
+    }
+  }
   if(name === "--MqttBroker".toLowerCase())
   {
     mqttBroker = value.replace(/^"/g, "").replace(/"$/g, "");
@@ -295,6 +308,7 @@ logger.output(`echonetCommandTimeout=${echonetCommandTimeout}`);
 logger.output(`debugLog=${debugLog}`);
 logger.output(`restApiPort=${restApiPort}`);
 logger.output(`restApiHost=${restApiHost}`);
+logger.output(`restApiRoot=${restApiRoot}`);
 logger.output(`mqttBroker=${mqttBroker}`);
 logger.output(`mqttOptionFile=${mqttOptionFile}`);
 logger.output(`mqttBaseTopic=${mqttBaseTopic}`);
@@ -315,6 +329,7 @@ const inputParameters:InputParameters =
   debugLog,
   restApiPort,
   restApiHost,
+  restApiRoot,
   mqttBroker,
   mqttOptionFile,
   mqttBaseTopic,
@@ -595,7 +610,7 @@ const detailLogsCallback : ()=>{fileName:string, content:string}[] = ()=>{
   return [{fileName, content}];
 }
 
-const restApiController = new RestApiController(deviceStore, systemStatusRepository, eventRepository, logger, echoNetListController, restApiHost, restApiPort, mqttBaseTopic, detailLogsCallback);
+const restApiController = new RestApiController(deviceStore, systemStatusRepository, eventRepository, logger, echoNetListController, restApiHost, restApiPort, restApiRoot, mqttBaseTopic, detailLogsCallback);
 restApiController.addPropertyChangedRequestEvent(async (deviceId:string, propertyName:string, newValue:any):Promise<void>=>{
 
   const device = deviceStore.getFromNameOrId(deviceId);

--- a/views/device.ejs
+++ b/views/device.ejs
@@ -2,7 +2,7 @@
     <div class="row">
       <nav aria-label="breadcrumb">
         <ol class="breadcrumb">
-          <li class="breadcrumb-item"><a href="/">Devices</a></li>
+          <li class="breadcrumb-item"><a href="<%= root %>">Devices</a></li>
           <li class="breadcrumb-item active" aria-current="page"><%= device.name %></li>
         </ol>
       </nav>
@@ -184,7 +184,7 @@
     
     $(function() {
 
-      const eventSource = new EventSource('/api/serverevents');
+      const eventSource = new EventSource('<%= root %>/api/serverevents');
       eventSource.addEventListener('systemUpdated', (event) => {
         updateSystem();
       });
@@ -207,7 +207,7 @@
       {
         $.ajax({
             type: "GET",
-            url: "/api/status",
+            url: "<%= root %>/api/status",
             dataType : "json"
           }).done((data)=>{
   
@@ -221,7 +221,7 @@
       {
         $.ajax({
             type: "GET",
-            url: "/elapi/v1/devices/<%= device.name %>",
+            url: "<%= root %>/elapi/v1/devices/<%= device.name %>",
             dataType : "json"
           }).done((data)=>{
   

--- a/views/device.ejs
+++ b/views/device.ejs
@@ -375,7 +375,7 @@ function sendParameter(propertyName)
   const body = {};
   body[propertyName] = editingObject[propertyName];
   $.ajax({
-    url:`/elapi/v1/devices/<%= device.name %>/properties/${propertyName}`,
+    url:`<%= root %>/elapi/v1/devices/<%= device.name %>/properties/${propertyName}`,
     type: "put",
     data: JSON.stringify( body ),
     contentType: 'application/json', //request type
@@ -388,7 +388,7 @@ function sendParameter(propertyName)
 function requestParameter(propertyName)
 {
   $.ajax({
-    url:`/elapi/v1/devices/<%= device.name %>/properties/${propertyName}/request`,
+    url:`<%= root %>/elapi/v1/devices/<%= device.name %>/properties/${propertyName}/request`,
     type: "put",
     data: "",
     dataType: 'json', // response type
@@ -456,7 +456,7 @@ function requestMultiParameter()
   }
 
   $.ajax({
-    url:`/elapi/v1/devices/<%= device.name %>/properties/request`,
+    url:`<%= root %>/elapi/v1/devices/<%= device.name %>/properties/request`,
     type: "put",
     data: json,
     contentType: 'application/json', //request type

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,7 +15,7 @@
   </div>
 </div>
 <script type="text/javascript">
-  const eventSource = new EventSource('/api/serverevents');
+  const eventSource = new EventSource('<%= root %>/api/serverevents');
   eventSource.addEventListener('systemUpdated', (event) => {
     updateSystem();
   });
@@ -28,7 +28,7 @@
     {
       $.ajax({
           type: "GET",
-          url: "/api/status",
+          url: "<%= root %>/api/status",
           dataType : "json"
         }).done((data)=>{
 

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>ECHONETLite2MQTT</title>
-    <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <link rel="shortcut icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="manifest" href="/site.webmanifest" />
+    <link rel="icon" type="image/png" href="<%= root %>/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="<%= root %>/favicon.svg" />
+    <link rel="shortcut icon" href="<%= root %>/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= root %>/apple-touch-icon.png" />
+    <link rel="manifest" href="<%= root %>/site.webmanifest" />
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
     <script type="text/javascript">
@@ -33,8 +33,8 @@
   <body>
     <nav class="navbar navbar-dark bg-primary navbar-expand-lg ">
       <div class="container-fluid">
-        <a class="navbar-brand" href="/">
-          <img src="/logo.svg" alt="" width="24" height="24" class="d-inline-block align-text-top" style="background-color : white">
+        <a class="navbar-brand" href="<%= root %>/">
+          <img src="<%= root %>/logo.svg" alt="" width="24" height="24" class="d-inline-block align-text-top" style="background-color : white">
           ECHONETLite2Mqtt
         </a>
 
@@ -44,13 +44,13 @@
         <div class="collapse navbar-collapse" id="navbarNav">
           <ul class="navbar-nav">
             <li class="nav-item">
-              <a id="rootmenu-devices" class="nav-link" href="/devices">Devices</a>
+              <a id="rootmenu-devices" class="nav-link" href="<%= root %>/devices">Devices</a>
             </li>
             <li class="nav-item">
-              <a id="rootmenu-logs" class="nav-link" href="/logs">Logs</a>
+              <a id="rootmenu-logs" class="nav-link" href="<%= root %>/logs">Logs</a>
             </li>
             <li class="nav-item">
-              <a id="rootmenu-logs" class="nav-link" href="/api-docs">Rest API</a>
+              <a id="rootmenu-logs" class="nav-link" href="<%= root %>/api-docs/">Rest API</a>
             </li>
           </ul>
         </div>

--- a/views/logs.ejs
+++ b/views/logs.ejs
@@ -12,14 +12,14 @@
         <tbody>
         </tbody>
       </table>
-      <a href="/downloadlogs/zip">Download Logs and internal statues for debug.</a>
+      <a href="<%= root %>/downloadlogs/zip">Download Logs and internal statues for debug.</a>
     </div>
   </div>
   <script type="text/javascript">
 
 
     $(function() {
-      const eventSource = new EventSource('/api/serverevents');
+      const eventSource = new EventSource('<%= root %>/api/serverevents');
       eventSource.addEventListener('systemUpdated', (event) => {
         console.log("SSE:systemUpdated");
         updateSystem();
@@ -36,7 +36,7 @@
       {
         $.ajax({
             type: "GET",
-            url: "/api/status",
+            url: "<%= root %>/api/status",
             dataType : "json"
           }).done((data)=>{
             $("#footer-version").text(data.systemVersion)
@@ -49,7 +49,7 @@
       {
         $.ajax({
             type: "GET",
-            url: "/api/logs",
+            url: "<%= root %>/api/logs",
             dataType : "json"
           }).done((data)=>{
             $("#logsTable tbody").children().remove();


### PR DESCRIPTION
Home Assistantのaddon機能をサポートいただけないでしょうか。

Home Assistantのaddonのビルドの環境は、全てha_addon内に入れてあります。
Home AssistantではWEB UIはingress経由でのアクセスとする(※)のが流儀のようなので、
本体にも多少手が入っていますが、REST_API_ROOTを設定せずに動かすと、元の通り動作するはずです。
※:
Home Assistantに対して、
<HomeAssistantIP>:<HomeAssistantPort>/aaa/bbb/ccc/ddd
のようにアクセスすると、
<内部アドレス>:<内部ポート>/ccc/ddd
のように、echonetlite2mqttには伝わります。
よって、app.getはそのままで良いのですが、hrefには/aaa/bbbを付けてやらないと適切に動作しないため、
これを入れるように変更を行なったつもりです。

[ビルドとイメージのパッケージ登録]の手順でビルドとパッケージ登録を行ない、
[Home Assistantのaddon公開用レポジトリ]に、addonインストールの設定ファイルをcommit、pushします。


[ビルドとイメージのパッケージ登録]
echonetlite2mqtt/.github/workflows/build_addon.yml
で行なっています。
現状は手動で実行するようになっています。
ビルドを行ない、パッケージを登録した後に
echonetlite2mqtt/ha_addon/config.yaml
の内容を一部変更し(versionとimage)、
[Home Assistantのaddon公開用レポジトリ]
にconfig.yamlを転送しています。

[Home Assistantのaddon公開用レポジトリ]
決まった形式である必要があるようです。
https://developers.home-assistant.io/docs/add-ons/repository
以下の例で試行しました(Intel NUCにインストールした稼動中のHome Assistantにaddonを組み込んで試しました)。
例:
https://github.com/yymyo1/home-assistant-addons
Home Assistant Matter Hubのものをforkして使っていたものに追加したものです。
ですので、hamhとhamh_testは(今回は)必要ないです。
echonetlite2mqtt/config.yamlは、本体のレポジトリからコピーしたものです。
