### PR TITLE
Home Assistantのbashio::serviceを使ったMQTT_*の取得

### DIFF
--- a/docker-entrypoint_addon.sh
+++ b/docker-entrypoint_addon.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bashio
 
+if bashio::services.available "mqtt"; then
+    bashio::log.info "MQTT service found, fetching credentials ..."
+    if bashio::var.true "$(bashio::services 'mqtt' 'ssl')"; then
+      MQTT_PREFIX="mqtts://";
+    else
+      MQTT_PREFIX="mqtt://";
+    fi
+    MQTT_HOST=$(bashio::services mqtt "host")
+    export MQTT_PORT=$(bashio::services mqtt "port")
+    export MQTT_USERNAME=$(bashio::services mqtt "username")
+    export MQTT_PASSWORD=$(bashio::services mqtt "password")
+    export MQTT_BROKER="${MQTT_PREFIX}${MQTT_HOST}:${MQTT_PORT}";
+fi
+
 if (bashio::config.has_value 'MQTT_BROKER'); then
   export MQTT_BROKER=$(bashio::config "MQTT_BROKER")
 fi


### PR DESCRIPTION
Home Assistantのaddon機能において、
Home AssistantでMQTTサービスを実行している場合には、
MQTT_*を設定しなくてもMQTT接続ができるようにしていただけないでしょうか。

現状(3.5.0)では、MQTT_*を設定してやらないとHome Assistantで動作しているMQTTサービスに接続できないようです。
おおよそ必要な内容は「$(bashio::services mqtt "username")」などで取得できるはずなので、
それで(デフォルト値を)取得できるようにしていただけないでしょうか。
何らかの理由でMQTT_*を手動で設定したい場合も考え、その設定より上で処理してやれば良いのではと思います。