### PR TITLE
Fix property map bitmap parsing

### DIFF
--- a/__tests__/EchoNetPropertyMapTests.ts
+++ b/__tests__/EchoNetPropertyMapTests.ts
@@ -1,0 +1,58 @@
+import 'jest';
+
+import EchoNetDeviceConverter from "../server/EchoNetDeviceConverter";
+import { RawDataSet } from "../server/EchoNetCommunicator";
+import { EchoNetLiteRawController } from "../server/EchoNetLiteRawController";
+
+class RawDataSetForTest implements RawDataSet {
+  public existsDevice = (_ip: string, _eoj: string): boolean => false;
+  public existsData = (_ip: string, _eoj: string, _epc: string): boolean => false;
+  public getIpList = (): string[] => [];
+  public getEojList = (_ip: string): string[] => [];
+  public getRawData = (_ip: string, _eoj: string, epc: string): string | undefined => {
+    if(epc !== "9f") {
+      return undefined;
+    }
+    return "40A595D5A7C4C4C5869795A7E471339392";
+  };
+}
+
+test("convert bitmap-format property maps", () => {
+  const expected = [
+    "80", "a0", "d0", "f0",
+    "81", "a1", "c1", "f1",
+    "82", "a2", "c2", "e2", "f2",
+    "83", "93", "a3", "d3", "f3",
+    "a4", "e4", "f4",
+    "a5", "e5", "f5",
+    "86", "a6", "e6", "f6",
+    "97", "a7", "f7",
+    "88", "98", "a8", "c8", "f8",
+    "89", "a9", "c9", "f9",
+    "8a", "9a", "aa", "da", "fa",
+    "ab", "db", "eb", "fb",
+    "8c", "cc", "dc", "ec",
+    "8d", "9d", "cd", "dd",
+    "8e", "9e", "ce", "fe",
+    "9f", "cf", "ff"
+  ];
+
+  expect(EchoNetLiteRawController.convertToPropertyList("40A595D5A7C4C4C5869795A7E471339392")).toEqual(expected);
+
+  const converter = new EchoNetDeviceConverter({ aliases: [] }, false, []);
+  expect(converter.convertGetPropertyNoList("192.0.2.1", "027d1f", new RawDataSetForTest())).toEqual(expected);
+});
+
+test("convert already-expanded property maps", () => {
+  expect(EchoNetLiteRawController.convertToPropertyList("048082838A")).toEqual([
+    "80", "82", "83", "8a"
+  ]);
+});
+
+test("prefer already-expanded maps when the length is ambiguous", () => {
+  const expandedSixteenProperties = "10808182838485868788898A8B8C8D8E8F";
+  expect(EchoNetLiteRawController.convertToPropertyList(expandedSixteenProperties)).toEqual([
+    "80", "81", "82", "83", "84", "85", "86", "87",
+    "88", "89", "8a", "8b", "8c", "8d", "8e", "8f"
+  ]);
+});

--- a/server/EchoNetDeviceConverter.ts
+++ b/server/EchoNetDeviceConverter.ts
@@ -46,19 +46,9 @@ export default class EchoNetDeviceConverter
       protocol = this.echoNetPropertyConverter.getProtocol(echonetLiteFacilities.getRawData(ip, eoj, "82")??"00000000", nodeProfileProtocol);
     }
 
-    const setPropertyNoList:string[] = [];
-    const setPropertyListText = echonetLiteFacilities.getRawData(ip, eoj,"9e") ?? "";
-    for(let i = 2; i < setPropertyListText.length; i+=2)
-    {
-      setPropertyNoList.push(setPropertyListText.substr(i, 2));
-    }
+    const setPropertyNoList:string[] = this.convertPropertyMapToList(echonetLiteFacilities.getRawData(ip, eoj,"9e") ?? "") ?? [];
 
-    const notifyPropertyNoList:string[] = [];
-    const notifyPropertyListText = echonetLiteFacilities.getRawData(ip, eoj, "9d") ?? "";
-    for(let i = 2; i < notifyPropertyListText.length; i+=2)
-    {
-      notifyPropertyNoList.push(notifyPropertyListText.substr(i, 2));
-    }
+    const notifyPropertyNoList:string[] = this.convertPropertyMapToList(echonetLiteFacilities.getRawData(ip, eoj, "9d") ?? "") ?? [];
 
     const newDevice = this.createDevice2(
       id, 
@@ -330,12 +320,58 @@ export default class EchoNetDeviceConverter
       return undefined;
     }
   
-    const getPropertyNoList:string[] = [];
-    for(let i = 2; i < getPropertyListText.length; i+=2)
+    return this.convertPropertyMapToList(getPropertyListText);
+  }
+
+  private convertPropertyMapToList = (propertyMapText:string): string[]|undefined => {
+    if(propertyMapText.length < 2)
     {
-      getPropertyNoList.push(getPropertyListText.substr(i, 2));
+      return undefined;
     }
-    return getPropertyNoList;
+
+    const propertyCount = parseInt(propertyMapText.substring(0, 2), 16);
+    const propertyNoList:string[] = [];
+
+    if(propertyMapText.length === 2 + propertyCount * 2)
+    {
+      for(let i = 2; i < propertyMapText.length; i+=2)
+      {
+        const propertyNo = propertyMapText.substr(i, 2).toLowerCase();
+        if(propertyNo.match(/[0-9a-f]{2}/) === null)
+        {
+          return undefined;
+        }
+        propertyNoList.push(propertyNo);
+      }
+      return propertyNoList;
+    }
+
+    // echonet-lite normally normalizes bitmap-format property maps to the
+    // expanded form above. This fallback keeps raw bitmap EDTs parseable if a
+    // future path bypasses that normalization.
+    if(propertyCount >= 16 && propertyMapText.length === 34)
+    {
+      for(let byteIndex=0; byteIndex<16; byteIndex++)
+      {
+        const byteText = propertyMapText.substr(2 + byteIndex * 2, 2).toLowerCase();
+        if(byteText.match(/[0-9a-f]{2}/) === null)
+        {
+          return undefined;
+        }
+        const byteValue = parseInt(byteText, 16);
+        for(let bitIndex=0; bitIndex<8; bitIndex++)
+        {
+          if((byteValue & (1 << bitIndex)) === 0)
+          {
+            continue;
+          }
+          propertyNoList.push((0x80 + bitIndex * 0x10 + byteIndex).toString(16).padStart(2, "0"));
+        }
+      }
+      return propertyNoList;
+    }
+
+    return undefined;
   }
 
   public getDeviceRawId = (ip:string, eoj:string, facilities:RawDataSet):string|undefined => {

--- a/server/EchoNetLiteRawController.ts
+++ b/server/EchoNetLiteRawController.ts
@@ -81,17 +81,49 @@ export class EchoNetLiteRawController {
     {
       return undefined;
     }
+    const propertyCount = parseInt(rawData.substring(0, 2), 16);
     const result:string[] = [];
-    for(let i=2;i<rawData.length;i+=2)
+
+    if(rawData.length === 2 + propertyCount * 2)
     {
-      const epc = rawData.substring(i, i+2).toLowerCase();
-      if(epc.match(/[0-9a-f]{2}/) === null)
+      for(let i=2;i<rawData.length;i+=2)
       {
-        return undefined;
+        const epc = rawData.substring(i, i+2).toLowerCase();
+        if(epc.match(/[0-9a-f]{2}/) === null)
+        {
+          return undefined;
+        }
+        result.push(epc);
       }
-      result.push(epc);
+      return result;
     }
-    return result;
+
+    // echonet-lite normally normalizes bitmap-format property maps to the
+    // expanded form above. This fallback keeps raw bitmap EDTs parseable if a
+    // future path bypasses that normalization.
+    if(propertyCount >= 16 && rawData.length === 34)
+    {
+      for(let byteIndex=0; byteIndex<16; byteIndex++)
+      {
+        const byteText = rawData.substring(2 + byteIndex * 2, 4 + byteIndex * 2).toLowerCase();
+        if(byteText.match(/[0-9a-f]{2}/) === null)
+        {
+          return undefined;
+        }
+        const byteValue = parseInt(byteText, 16);
+        for(let bitIndex=0; bitIndex<8; bitIndex++)
+        {
+          if((byteValue & (1 << bitIndex)) === 0)
+          {
+            continue;
+          }
+          result.push((0x80 + bitIndex * 0x10 + byteIndex).toString(16).padStart(2, "0"));
+        }
+      }
+      return result;
+    }
+
+    return undefined;
   }
 
   private findProperty = (ip: string, eoj: string, epc: string): RawDeviceProperty | undefined  =>{


### PR DESCRIPTION
## 概要

ECHONET Lite の property map (`9D` / `9E` / `9F`) には、通常の `count + EPC list` 形式に加えて、プロパティ数が 16 個以上の場合に使われる bitmap 形式があります。

この PR では、ECHONETLite2MQTT 側の raw discovery と device converter でも両方の形式を扱えるようにし、raw bitmap EDT を受け取った場合の fallback として動作するようにしています。

## 補足

通常の受信経路では、依存ライブラリ `echonet-lite` が bitmap 形式の property map を展開済みの形式へ正規化しているようです。そのため、この変更が現在確認している discovery 問題の直接原因を修正するものとは断定していません。

手元の蓄電池オブジェクト (`027D1F`) では、調査中に bitmap 形式の `9F` を確認しました。

```text
40A595D5A7C4C4C5869795A7E471339392
```

一方で、v3.7.3 の実行中インスタンスでは `9F` が展開済みの形式として保持されているケースも確認しました。

このため、本 PR は「現状の discovery 問題の根本修正」というより、ECHONETLite2MQTT 側でも標準の bitmap 形式を扱えるようにする堅牢性向上として提案します。必要性についてはご判断いただければと思います。

## 変更内容

- 通常形式と bitmap 形式の property map 解析に対応
- raw discovery と device converter の `9F` / `9E` / `9D` 解析を修正
- 既に展開済みの map を優先するテストを追加
- bitmap 形式と従来の列挙形式の単体テストを追加

## 確認

- `npm run build`
- `npm test -- --runInBand`