### PR TITLE
デバイス探索の再実行を安定化する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -90,6 +90,7 @@ ECHONET Lite と MQTT をつなぐブリッジです。
 echonetlite2mqttは同じネットワーク内のデバイスを自動で見つけます。
 そのため、デバイスと同じネットワークで実行する必要があります。
 また、docker使用時は、 `--net=host` が必要です。
+起動時にデバイスが検出されない場合は、デバイス一覧ページの `Rescan` ボタン、または `POST /api/discovery/rescan` を使用できます。
 
 
 ### Home AssistantのAddonとして使用する場合
@@ -169,6 +170,8 @@ ECHONET Lite オプション
 | `ECHONET_TARGET_NETWORK` | `--echonetTargetNetwork` | ECHONET Liteのネットワークを"000.000.000.000/00"の形で指定します。 (デフォルト: 自動) |
 | `ECHONET_DEVICE_IP_LIST` | `--echonetDeviceIpList` | デバイスのIPをカンマ区切りで指定します。(デフォルト:無し) |
 | `ECHONET_COMMAND_TIMEOUT` | `--echonetCommandTimeout` | ECHONET Liteコマンドの応答待ちの時間を指定します. (単位: ms) (デフォルト: 3000) |
+| `ECHONET_DISCOVERY_STARTUP_RETRY_INTERVALS` | `--echonetDiscoveryStartupRetryIntervals` | 起動後の自動探索を再実行するタイミングを秒数のカンマ区切りで指定します。空文字を指定すると起動後の再探索を無効にします。(デフォルト: 15,60) |
+| `ECHONET_DISCOVERY_PERIODIC_INTERVAL` | `--echonetDiscoveryPeriodicInterval` | 定期的な自動探索の間隔を秒数で指定します。0を指定すると定期探索を無効にします。(デフォルト: 0) |
 | `ECHONET_DISABLE_AUTO_DEVICE_DISCOVERY` | `--echonetDisableAutoDeviceDiscovery` | デバイスの自動探索を無効にします。(デフォルト: off) |
 | `ECHONET_ALIAS_FILE`   | `--echonetAliasFile`  | エイリアスオプションファイルを指定します。 (デフォルト: 使用しない) |
 | `ECHONET_LEGACY_MULTI_NIC_MODE` | `--echonetLegacyMultiNicMode` | 以前の通信モードに戻します。 (デフォルト: off) |

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The supported devices are as follows.
 echonetlite2mqtt automatically finds devices in the same network.
 Therefore, echonetlite2mqtt must be run on the same network as the devices.
 Also, when using docker, `--net=host` is required.
+If a device is not detected at startup, use the `Rescan` button on the devices page or `POST /api/discovery/rescan`.
 
 ### As a Home Assistant Add-on
 
@@ -174,6 +175,8 @@ ECHONET Lite Options
 | `ECHONET_TARGET_NETWORK` | `--echonetTargetNetwork` | Specify the network for ECHONET Lite in the format "000.000.000.000/00". (Default: Auto) |
 | `ECHONET_DEVICE_IP_LIST`                | `--echonetDeviceIpList`               | Specify the device IPs separated by commas. (Default: none) |
 | `ECHONET_COMMAND_TIMEOUT` | `--echonetCommandTimeout` | Specify the timeout for ECHONET Lite commands. (Unit: ms) (Default: 3000) |
+| `ECHONET_DISCOVERY_STARTUP_RETRY_INTERVALS` | `--echonetDiscoveryStartupRetryIntervals` | Retry automatic discovery after startup. Specify seconds separated by commas. Use an empty value to disable startup retries. (Default: 15,60) |
+| `ECHONET_DISCOVERY_PERIODIC_INTERVAL` | `--echonetDiscoveryPeriodicInterval` | Run periodic automatic discovery. Specify the interval in seconds. 0 disables periodic discovery. (Default: 0) |
 | `ECHONET_DISABLE_AUTO_DEVICE_DISCOVERY` | `--echonetDisableAutoDeviceDiscovery` | Disable automatic device discovery. (default: off) |
 | `ECHONET_ALIAS_FILE`   | `--echonetAliasFile`  | The file path for alias option file. (Defalt: not use) |
 | `ECHONET_LEGACY_MULTI_NIC_MODE` | `--echonetLegacyMultiNicMode` | Revert to legacy communication mode. (Default: off) |

--- a/__tests__/DiscoveryOptionsTests.ts
+++ b/__tests__/DiscoveryOptionsTests.ts
@@ -1,0 +1,30 @@
+import 'jest';
+import { parseDiscoveryPeriodicInterval, parseDiscoveryStartupRetryIntervals } from '../server/discoveryOptions';
+
+describe('discovery option parser', () => {
+  test('parse startup retry intervals', () => {
+    expect(parseDiscoveryStartupRetryIntervals('15,60')).toEqual([15, 60]);
+    expect(parseDiscoveryStartupRetryIntervals('"5, 30"')).toEqual([5, 30]);
+  });
+
+  test('allow empty startup retry intervals', () => {
+    expect(parseDiscoveryStartupRetryIntervals('')).toEqual([]);
+    expect(parseDiscoveryStartupRetryIntervals('""')).toEqual([]);
+  });
+
+  test('reject invalid startup retry intervals', () => {
+    expect(parseDiscoveryStartupRetryIntervals('15,-1')).toBeUndefined();
+    expect(parseDiscoveryStartupRetryIntervals('15,abc')).toBeUndefined();
+  });
+
+  test('parse periodic discovery interval', () => {
+    expect(parseDiscoveryPeriodicInterval('0')).toBe(0);
+    expect(parseDiscoveryPeriodicInterval('"120"')).toBe(120);
+  });
+
+  test('reject invalid periodic discovery interval', () => {
+    expect(parseDiscoveryPeriodicInterval('')).toBeUndefined();
+    expect(parseDiscoveryPeriodicInterval('-1')).toBeUndefined();
+    expect(parseDiscoveryPeriodicInterval('abc')).toBeUndefined();
+  });
+});

--- a/__tests__/RawNodeMergeTests.ts
+++ b/__tests__/RawNodeMergeTests.ts
@@ -1,0 +1,109 @@
+import 'jest';
+import { EchoNetLiteRawController, RawNode } from '../server/EchoNetLiteRawController';
+
+const mergeNode = (current:RawNode|undefined, next:RawNode):RawNode =>
+  (EchoNetLiteRawController as any).mergeNode(current, next) as RawNode;
+
+const property = (epc:string, value:string, operation:{get?:boolean, set?:boolean, inf?:boolean}) => ({
+  ip: '192.168.11.249',
+  eoj: '027201',
+  epc,
+  value,
+  operation: {
+    get: operation.get === true,
+    set: operation.set === true,
+    inf: operation.inf === true
+  }
+});
+
+describe('raw node discovery merge', () => {
+  test('keeps devices missing from a later partial scan', () => {
+    const current:RawNode = {
+      ip: '192.168.11.249',
+      devices: [
+        {ip: '192.168.11.249', eoj: '0ef001', noExistsId: false, properties: []},
+        {ip: '192.168.11.249', eoj: '027201', noExistsId: false, properties: [property('83', 'id-water-heater', {get: true})]}
+      ]
+    };
+    const next:RawNode = {
+      ip: '192.168.11.249',
+      devices: [
+        {ip: '192.168.11.249', eoj: '0ef001', noExistsId: false, properties: []}
+      ]
+    };
+
+    const merged = mergeNode(current, next);
+
+    expect(merged.devices.map(_=>_.eoj)).toEqual(['0ef001', '027201']);
+  });
+
+  test('preserves previous property values when a later scan times out', () => {
+    const current:RawNode = {
+      ip: '192.168.11.249',
+      devices: [
+        {
+          ip: '192.168.11.249',
+          eoj: '027201',
+          noExistsId: false,
+          properties: [
+            property('83', 'id-water-heater', {get: true}),
+            property('8a', '000082', {get: true})
+          ]
+        }
+      ]
+    };
+    const next:RawNode = {
+      ip: '192.168.11.249',
+      devices: [
+        {
+          ip: '192.168.11.249',
+          eoj: '027201',
+          noExistsId: true,
+          properties: [
+            property('83', '', {get: true}),
+            property('9f', '02838a', {})
+          ]
+        }
+      ]
+    };
+
+    const merged = mergeNode(current, next);
+    const mergedDevice = merged.devices.find(_=>_.eoj === '027201');
+
+    expect(mergedDevice?.noExistsId).toBe(false);
+    expect(mergedDevice?.properties.find(_=>_.epc === '83')?.value).toBe('id-water-heater');
+    expect(mergedDevice?.properties.find(_=>_.epc === '8a')?.value).toBe('000082');
+    expect(mergedDevice?.properties.find(_=>_.epc === '9f')?.value).toBe('02838a');
+  });
+
+  test('updates property values and keeps operation flags from both scans', () => {
+    const current:RawNode = {
+      ip: '192.168.11.249',
+      devices: [
+        {
+          ip: '192.168.11.249',
+          eoj: '027201',
+          noExistsId: false,
+          properties: [property('80', '31', {get: true})]
+        }
+      ]
+    };
+    const next:RawNode = {
+      ip: '192.168.11.249',
+      devices: [
+        {
+          ip: '192.168.11.249',
+          eoj: '027201',
+          noExistsId: false,
+          properties: [property('80', '30', {inf: true})]
+        }
+      ]
+    };
+
+    const merged = mergeNode(current, next);
+    const mergedProperty = merged.devices[0].properties.find(_=>_.epc === '80');
+
+    expect(mergedProperty?.value).toBe('30');
+    expect(mergedProperty?.operation).toEqual({get: true, set: false, inf: true});
+  });
+});

--- a/server/EchoNetLiteController.ts
+++ b/server/EchoNetLiteController.ts
@@ -10,6 +10,16 @@ import { Logger } from "./Logger";
 export type findDeviceCallback = (internalId:string)=>Readonly<Device>|undefined;
 export type findDeviceByIpEojCallback = (ip:string, eoj:string)=>Readonly<Device>|undefined;
 
+export type DiscoveryRunStatus = "completed" | "busy" | "error";
+export interface DiscoveryRunResult{
+  status:DiscoveryRunStatus;
+  reason:string;
+  targetIp?:string;
+  startedAt:string;
+  finishedAt:string;
+  message?:string;
+}
+
 export class EchoNetLiteController{
   
   private readonly aliasOption: AliasOption;
@@ -23,18 +33,27 @@ export class EchoNetLiteController{
   private readonly knownDeviceIpList:string[];
   private readonly searchDevices:boolean;
   private readonly commandTimeout:number;
+  private readonly startupRetryIntervals:number[];
+  private readonly periodicDiscoveryInterval:number;
   private readonly findDeviceCallback:findDeviceCallback;
   private readonly findDeviceByIpEojCallback:findDeviceByIpEojCallback;
-  constructor(usedIpByEchoNet:string,  
-    aliasOption: AliasOption, 
-    legacyMultiNicMode:boolean, 
+  private discoveryInProgress = false;
+  private readonly unknownDeviceDiscoveryTimers:{[ip:string]:NodeJS.Timeout} = {};
+  private readonly lastUnknownDeviceDiscoveryAt:{[ip:string]:number} = {};
+  private readonly unknownDeviceDiscoveryDelayMilliseconds = 2000;
+  private readonly unknownDeviceDiscoveryCooldownMilliseconds = 60 * 1000;
+  constructor(usedIpByEchoNet:string,
+    aliasOption: AliasOption,
+    legacyMultiNicMode:boolean,
     unknownAsError:boolean,
     knownDeviceIpList:string[],
     searchDevices:boolean,
     commandTimeout:number,
     findDeviceCallback:findDeviceCallback,
     findDeviceByIpEojCallback:findDeviceByIpEojCallback,
-    additionalMraFolders:string[])
+    additionalMraFolders:string[],
+    startupRetryIntervals:number[] = [15, 60],
+    periodicDiscoveryInterval:number = 0)
   {
     this.aliasOption = aliasOption;
     this.deviceConverter = new EchoNetDeviceConverter(this.aliasOption, unknownAsError, additionalMraFolders);
@@ -47,6 +66,8 @@ export class EchoNetLiteController{
 
     this.usedIpByEchoNet = usedIpByEchoNet;
     this.commandTimeout = commandTimeout;
+    this.startupRetryIntervals = startupRetryIntervals;
+    this.periodicDiscoveryInterval = periodicDiscoveryInterval;
     this.findDeviceCallback = findDeviceCallback;
     this.findDeviceByIpEojCallback = findDeviceByIpEojCallback;
 
@@ -230,11 +251,15 @@ export class EchoNetLiteController{
 
   private ReceivedGetResponse = async ( rinfo:rinfo, els:eldata ):Promise<void>=>
   {
-
+    this.scheduleDiscoveryForUnknownDevice(rinfo.address, els.SEOJ, "response");
   };
   ReceivedInfo = ( rinfo:rinfo, els:eldata ):void=>
   {
-  
+    if("d5" in els.DETAILs)
+    {
+      return;
+    }
+    this.scheduleDiscoveryForUnknownDevice(rinfo.address, els.SEOJ, "inf");
   };
   ReceivedGet = (( rinfo:rinfo, els:eldata ):void=>
   {
@@ -275,6 +300,130 @@ export class EchoNetLiteController{
   }
   fireDeviceUpdated = (lastDevice:Device, device:Device):void=>{
     this.deviceUpdatedListeners.forEach(_=>_(lastDevice, device));
+  }
+
+  private scheduleDiscoveryForUnknownDevice = (ip:string, eoj:string, reason:string):void=>
+  {
+    if(this.searchDevices===false)
+    {
+      return;
+    }
+    if(this.discoveryInProgress)
+    {
+      return;
+    }
+    if(ip === "" || ip === this.usedIpByEchoNet || eoj === "05ff01")
+    {
+      return;
+    }
+    if(this.findDeviceByIpEojCallback(ip, eoj) !== undefined)
+    {
+      return;
+    }
+
+    const now = Date.now();
+    const lastDiscoveryAt = this.lastUnknownDeviceDiscoveryAt[ip] ?? 0;
+    if(now - lastDiscoveryAt < this.unknownDeviceDiscoveryCooldownMilliseconds)
+    {
+      return;
+    }
+    if(this.unknownDeviceDiscoveryTimers[ip] !== undefined)
+    {
+      return;
+    }
+
+    Logger.info("[ECHONETLite]", `schedule discovery from unknown ${reason}: ${ip} ${eoj}`);
+    this.lastUnknownDeviceDiscoveryAt[ip] = now;
+    this.unknownDeviceDiscoveryTimers[ip] = setTimeout(()=>{
+      delete this.unknownDeviceDiscoveryTimers[ip];
+      void this.runDiscovery(`unknown-${reason}`, ip, false);
+    }, this.unknownDeviceDiscoveryDelayMilliseconds);
+  }
+
+  public runDiscovery = async (reason:string, targetIp:string|undefined=undefined, forceNetworkDiscovery=false):Promise<DiscoveryRunResult> =>
+  {
+    const startedAt = new Date().toISOString();
+    if(this.discoveryInProgress)
+    {
+      return {
+        status:"busy",
+        reason,
+        targetIp,
+        startedAt,
+        finishedAt:new Date().toISOString(),
+        message:"discovery is already running"
+      };
+    }
+
+    this.discoveryInProgress = true;
+    let status:DiscoveryRunStatus = "completed";
+    let message:string|undefined;
+    try
+    {
+      Logger.info("[ECHONETLite]", `discovery started: ${reason}${targetIp !== undefined ? ` ${targetIp}` : ""}`);
+      if(targetIp !== undefined)
+      {
+        Logger.info("[ECHONETLite]", `collecting devices from ${targetIp}`);
+        await this.echonetLiteRawController.searchDeviceFromIp(targetIp);
+      }
+      else
+      {
+        if(this.knownDeviceIpList.length > 0)
+        {
+          for(const ip of this.knownDeviceIpList)
+          {
+            Logger.info("[ECHONETLite]", `collecting devices from ${ip}`);
+            await this.echonetLiteRawController.searchDeviceFromIp(ip);
+          }
+          Logger.info("[ECHONETLite]", `done collecting devices`);
+        }
+        if(this.searchDevices || forceNetworkDiscovery)
+        {
+          Logger.info("[ECHONETLite]", `searching devices...`);
+          await this.echonetLiteRawController.searchDevicesInNetwork();
+          Logger.info("[ECHONETLite]", `done searching devices`);
+        }
+      }
+    }
+    catch(e)
+    {
+      status = "error";
+      message = e instanceof Error ? e.message : JSON.stringify(e);
+      Logger.warn("[ECHONETLite]", `discovery error: ${reason}`, {exception:e});
+    }
+    finally
+    {
+      this.discoveryInProgress = false;
+    }
+
+    const finishedAt = new Date().toISOString();
+    Logger.info("[ECHONETLite]", `discovery finished: ${reason} ${status}`);
+    return {status, reason, targetIp, startedAt, finishedAt, message};
+  }
+
+  private startDiscoveryTimers = ():void =>
+  {
+    void this.runStartupDiscoveryRetries();
+    if(this.periodicDiscoveryInterval > 0)
+    {
+      setInterval(()=>{
+        void this.runDiscovery(`periodic-${this.periodicDiscoveryInterval}s`, undefined, false);
+      }, this.periodicDiscoveryInterval * 1000);
+    }
+  }
+
+  private runStartupDiscoveryRetries = async ():Promise<void> =>
+  {
+    for(const interval of this.startupRetryIntervals)
+    {
+      await this.wait(interval * 1000);
+      await this.runDiscovery(`startup-retry-${interval}s`, undefined, false);
+    }
+  }
+
+  private wait = async (milliseconds:number):Promise<void> =>
+  {
+    await new Promise<void>((resolve)=>setTimeout(()=>resolve(), milliseconds));
   }
 
 
@@ -394,21 +543,8 @@ export class EchoNetLiteController{
 
     await (new Promise<void>((resolve)=>setTimeout(()=>resolve(), 1000)));
 
-    if(this.knownDeviceIpList.length > 0)
-    {
-      for(const ip of this.knownDeviceIpList)
-      {
-        Logger.info("[ECHONETLite]", `collecting devices from ${ip}`);
-        await this.echonetLiteRawController.searchDeviceFromIp(ip);
-      }
-      Logger.info("[ECHONETLite]", `done collecting devices`);
-    }
-    if(this.searchDevices)
-    {
-      Logger.info("[ECHONETLite]", `searching devices...`);
-      await this.echonetLiteRawController.searchDevicesInNetwork();
-      Logger.info("[ECHONETLite]", `done searching devices`);
-    }
+    await this.runDiscovery("startup", undefined, false);
+    this.startDiscoveryTimers();
   }
 
   requestDeviceProperty = async (id:DeviceId, propertyName:string):Promise<void> =>

--- a/server/EchoNetLiteRawController.ts
+++ b/server/EchoNetLiteRawController.ts
@@ -129,6 +129,107 @@ export class EchoNetLiteRawController {
     return response.els.DETAILs[epc];
   }
 
+  private static getPropertyMap = async (ip: string, eoj: string, epc: string, retryCount = 2): Promise<{res:CommandResponse, edt:{[key:string]:string}} | undefined> =>{
+    for(let i = 0; i <= retryCount; i++)
+    {
+      let res: CommandResponse;
+      try
+      {
+        res = await EchoNetCommunicator.execCommandPromise(ip, "0ef001", eoj, ELSV.GET, epc, "");
+      }
+      catch(e)
+      {
+        Logger.warn("[ECHONETLite][raw]", `error getNewNode: get ${epc}: exception from ${ip},${eoj}`, {exception:e});
+        continue;
+      }
+      const response = res.matchResponse(_=>_.els.ESV === ELSV.GET_RES && (epc in _.els.DETAILs));
+      if(response === undefined)
+      {
+        Logger.warn("[ECHONETLite][raw]", `error getNewNode: get ${epc} from ${ip},${eoj}`, {responses:res.responses, command:res.command});
+        continue;
+      }
+      return {res, edt:response.els.DETAILs};
+    }
+
+    return undefined;
+  }
+
+  private static cloneProperty = (property: RawDeviceProperty): RawDeviceProperty => ({
+    ip: property.ip,
+    eoj: property.eoj,
+    epc: property.epc,
+    value: property.value,
+    operation: {
+      get: property.operation.get,
+      set: property.operation.set,
+      inf: property.operation.inf
+    }
+  });
+
+  private static cloneDevice = (device: RawDevice): RawDevice => ({
+    ip: device.ip,
+    eoj: device.eoj,
+    properties: device.properties.map(_=>EchoNetLiteRawController.cloneProperty(_)),
+    noExistsId: device.noExistsId
+  });
+
+  private static cloneNode = (node: RawNode): RawNode => ({
+    ip: node.ip,
+    devices: node.devices.map(_=>EchoNetLiteRawController.cloneDevice(_))
+  });
+
+  private static mergeProperty = (current: RawDeviceProperty, next: RawDeviceProperty): RawDeviceProperty => ({
+    ip: next.ip,
+    eoj: next.eoj,
+    epc: next.epc,
+    value: next.value !== "" || current.value === "" ? next.value : current.value,
+    operation: {
+      get: current.operation.get || next.operation.get,
+      set: current.operation.set || next.operation.set,
+      inf: current.operation.inf || next.operation.inf
+    }
+  });
+
+  private static mergeDevice = (current: RawDevice, next: RawDevice): RawDevice => {
+    const result = EchoNetLiteRawController.cloneDevice(current);
+    result.ip = next.ip;
+    result.eoj = next.eoj;
+    result.noExistsId = current.noExistsId && next.noExistsId;
+
+    for(const nextProperty of next.properties)
+    {
+      const currentIndex = result.properties.findIndex(_=>_.epc === nextProperty.epc);
+      if(currentIndex === -1)
+      {
+        result.properties.push(EchoNetLiteRawController.cloneProperty(nextProperty));
+        continue;
+      }
+      result.properties[currentIndex] = EchoNetLiteRawController.mergeProperty(result.properties[currentIndex], nextProperty);
+    }
+    return result;
+  }
+
+  private static mergeNode = (current: RawNode|undefined, next: RawNode): RawNode => {
+    if(current === undefined)
+    {
+      return EchoNetLiteRawController.cloneNode(next);
+    }
+
+    const result = EchoNetLiteRawController.cloneNode(current);
+    result.ip = next.ip;
+    for(const nextDevice of next.devices)
+    {
+      const currentIndex = result.devices.findIndex(_=>_.eoj === nextDevice.eoj);
+      if(currentIndex === -1)
+      {
+        result.devices.push(EchoNetLiteRawController.cloneDevice(nextDevice));
+        continue;
+      }
+      result.devices[currentIndex] = EchoNetLiteRawController.mergeDevice(result.devices[currentIndex], nextDevice);
+    }
+    return result;
+  }
+
   private static async getNewNode(node: RawNode): Promise<RawNode> {
     const result: RawNode = {
       ip: node.ip,
@@ -145,29 +246,18 @@ export class EchoNetLiteRawController {
     {
       for(const epc of ["9f", "9e", "9d"])
       {
-        let res: CommandResponse;
-        try
+        const propertyMapResponse = await EchoNetLiteRawController.getPropertyMap(result.ip, device.eoj, epc);
+        if(propertyMapResponse === undefined)
         {
-          res = await EchoNetCommunicator.execCommandPromise(result.ip, "0ef001", device.eoj, ELSV.GET, epc, "");
-        }
-        catch(e)
-        {
-          Logger.warn("[ECHONETLite][raw]", `error getNewNode: get ${epc}: exception from ${result.ip},${device.eoj}`, {exception:e});
-          continue;
-        }
-        const response = res.matchResponse(_=>_.els.ESV === ELSV.GET_RES && (epc in _.els.DETAILs));
-        if(response === undefined)
-        {
-          Logger.warn("[ECHONETLite][raw]", `error getNewNode: get ${epc} from ${result.ip},${device.eoj}`, {responses:res.responses, command:res.command});
           continue;
         }
 
-        const edt = response.els.DETAILs;
+        const edt = propertyMapResponse.edt;
         const data = edt[epc];
         const propertyList = EchoNetLiteRawController.convertToPropertyList(data);
         if(propertyList === undefined)
         {
-          Logger.warn("[ECHONETLite][raw]", `error getNewNode: get ${epc}: invalid reveive data ${result.ip},${device.eoj} ${JSON.stringify(edt)}`, {responses:res.responses, command:res.command});
+          Logger.warn("[ECHONETLite][raw]", `error getNewNode: get ${epc}: invalid reveive data ${result.ip},${device.eoj} ${JSON.stringify(edt)}`, {responses:propertyMapResponse.res.responses, command:propertyMapResponse.res.command});
           continue;
         }
         for(const propertyMapEpc of propertyList)
@@ -287,6 +377,22 @@ export class EchoNetLiteRawController {
     return result;
   }
 
+  private upsertNode = (newNode: RawNode): RawNode => {
+    const currentIndex = this.nodes.findIndex(_=>_.ip === newNode.ip);
+    const mergedNode = EchoNetLiteRawController.mergeNode(
+      currentIndex === -1 ? undefined : this.nodes[currentIndex],
+      newNode);
+    if(currentIndex===-1)
+    {
+      this.nodes.push(mergedNode);
+    }
+    else
+    {
+      this.nodes[currentIndex] = mergedNode;
+    }
+    return mergedNode;
+  }
+
 
 
 
@@ -328,16 +434,8 @@ export class EchoNetLiteRawController {
 
             // ノート応答が遅い場合ここで待たされることになるが、一旦あきらめる
             const newNode = await EchoNetLiteRawController.getNewNode(nodeTemp);
-            const currentIndex = this.nodes.findIndex(_=>_.ip === newNode.ip);
-            if(currentIndex===-1)
-            {
-              this.nodes.push(newNode);
-            }
-            else
-            {
-              this.nodes[currentIndex] = newNode;
-            }
-            this.fireDeviceDetected(newNode.ip, newNode.devices.map(_=>_.eoj));
+            const mergedNode = this.upsertNode(newNode);
+            this.fireDeviceDetected(mergedNode.ip, mergedNode.devices.map(_=>_.eoj));
           }
           continue;
         }
@@ -372,16 +470,8 @@ export class EchoNetLiteRawController {
             });
 
             const newNode = await EchoNetLiteRawController.getNewNode(nodeTemp);
-            const currentIndex = this.nodes.findIndex(_=>_.ip === newNode.ip);
-            if(currentIndex===-1)
-            {
-              this.nodes.push(newNode);
-            }
-            else
-            {
-              this.nodes[currentIndex] = newNode;
-            }
-            this.fireDeviceDetected(newNode.ip, newNode.devices.map(_=>_.eoj));
+            const mergedNode = this.upsertNode(newNode);
+            this.fireDeviceDetected(mergedNode.ip, mergedNode.devices.map(_=>_.eoj));
 
           }
         }
@@ -565,17 +655,8 @@ export class EchoNetLiteRawController {
     // ノードの詳細を取得する
     const newNode = await EchoNetLiteRawController.getNewNode(node);
 
-    const currentIndex = this.nodes.findIndex(_=>_.ip === newNode.ip);
-    if(currentIndex===-1)
-    {
-      this.nodes.push(newNode);
-    }
-    else
-    {
-      this.nodes[currentIndex] = newNode;
-    }
-
-    this.fireDeviceDetected(newNode.ip, newNode.devices.map(_=>_.eoj));
+    const mergedNode = this.upsertNode(newNode);
+    this.fireDeviceDetected(mergedNode.ip, mergedNode.devices.map(_=>_.eoj));
   }
 
   public searchDevicesInNetwork = async (): Promise<void> =>{
@@ -628,16 +709,8 @@ export class EchoNetLiteRawController {
         throw Error("ありえない");
       }
       const newNode = await EchoNetLiteRawController.getNewNode(node);
-      const currentIndex = this.nodes.findIndex(_=>_.ip === newNode.ip);
-      if(currentIndex===-1)
-      {
-        this.nodes.push(newNode);
-      }
-      else
-      {
-        this.nodes[currentIndex] = newNode;
-      }
-      this.fireDeviceDetected(newNode.ip, newNode.devices.map(_=>_.eoj));
+      const mergedNode = this.upsertNode(newNode);
+      this.fireDeviceDetected(mergedNode.ip, mergedNode.devices.map(_=>_.eoj));
     }
   }
 

--- a/server/RestApiController.ts
+++ b/server/RestApiController.ts
@@ -7,7 +7,7 @@ import { Device } from "./Property";
 import expressLayouts from 'express-ejs-layouts';
 import { ElDataType, ElMixedOneOfType } from "./MraTypes";
 import admZip from 'adm-zip';
-import { EchoNetLiteController } from "./EchoNetLiteController";
+import { DiscoveryRunResult, EchoNetLiteController } from "./EchoNetLiteController";
 import { Logger } from "./Logger";
 import path from "path";
 import crypto from "crypto";
@@ -35,6 +35,7 @@ export class RestApiController
   private readonly detailLogsCallback:()=>{fileName:string, content:string}[];
   private wss:WebSocketServer|undefined;
   private readonly serverSentEventMethod:"websocket" | "longpolling"
+  private readonly isDiscoveryTargetIpAllowed:(ip:string)=>boolean;
 
   constructor(deviceStore:DeviceStore, 
     systemStatusRepository:SystemStatusRepositry,
@@ -46,7 +47,8 @@ export class RestApiController
     root:string,
     mqttBaseTopic:string,
     detailLogsCallback:()=>{fileName:string, content:string}[],
-    serverSentEventMethod:"websocket" | "longpolling"){
+    serverSentEventMethod:"websocket" | "longpolling",
+    isDiscoveryTargetIpAllowed:(ip:string)=>boolean = ()=>true){
 
     this.deviceStore = deviceStore;
     this.systemStatusRepository = systemStatusRepository;
@@ -59,6 +61,7 @@ export class RestApiController
     this.mqttBaseTopic = mqttBaseTopic;
     this.detailLogsCallback = detailLogsCallback;
     this.serverSentEventMethod = serverSentEventMethod;
+    this.isDiscoveryTargetIpAllowed = isDiscoveryTargetIpAllowed;
 
     setInterval(this.timeoutLongPolling, 10*1000);
   }
@@ -95,6 +98,8 @@ export class RestApiController
     app.put("/elapi/v1/devices/:deviceId/properties/:propertyName/request", this.requestProperty);
 
     app.get("/api/status", this.getStatus);
+    app.post("/api/discovery/rescan", this.rescanDevices);
+    app.post("/api/discovery/rescan/:ip", this.rescanDeviceByIp);
     app.get("/api/events", this.getEventsWithLongPolling);  // OBSOLETE
     app.get("/api/logs", this.getLogs);
     
@@ -677,9 +682,48 @@ export class RestApiController
         protocol:_.protocol
       }
     ))
-  
+
     res.json(result);
   }
+
+  private rescanDevices = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<void> => {
+    const result:DiscoveryRunResult = await this.echoNetLiteController.runDiscovery("manual", undefined, true);
+    res.json(result);
+  }
+
+  private rescanDeviceByIp = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<void> => {
+    const ip = req.params.ip;
+    if(this.isValidIPv4(ip)===false)
+    {
+      res.status(400);
+      res.json({status:"error", reason:"manual", targetIp:ip, startedAt:new Date().toISOString(), finishedAt:new Date().toISOString(), message:"invalid ip address"});
+      return;
+    }
+    if(this.isDiscoveryTargetIpAllowed(ip)===false)
+    {
+      res.status(403);
+      res.json({status:"error", reason:"manual", targetIp:ip, startedAt:new Date().toISOString(), finishedAt:new Date().toISOString(), message:"target ip address is outside the ECHONET Lite network"});
+      return;
+    }
+
+    const result:DiscoveryRunResult = await this.echoNetLiteController.runDiscovery("manual", ip, false);
+    res.json(result);
+  }
+
+  private isValidIPv4 = (ip:string):boolean => {
+    if(ip.match(/^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$/) === null)
+    {
+      return false;
+    }
+    return ip.split(".").map(_=>Number(_)).every(_=>isNaN(_)===false && _ >= 0 && _ <= 255);
+  }
+
   private getLogs = (
     req: express.Request,
     res: express.Response

--- a/server/RestApiOpenApiConverter.ts
+++ b/server/RestApiOpenApiConverter.ts
@@ -44,6 +44,8 @@ export class RestApiOpenApiConverter{
       result.paths = {};
     }
     result.paths[`/api/status`] = this.getSystemStatus();
+    result.paths[`/api/discovery/rescan`] = this.postDiscoveryRescan();
+    result.paths[`/api/discovery/rescan/{ip}`] = this.postDiscoveryRescanIp();
     result.paths[`/api/logs`] = this.getLogs();
     result.paths[`/api/serverevents`] = this.getServerEvents();
 
@@ -79,6 +81,7 @@ export class RestApiOpenApiConverter{
       result.components.schemas["ApiDevice"] = this.getComponentsApiDevice();
       result.components.schemas["ApiDeviceProperty"] = this.getComponentsApiDeviceProperty();
       result.components.schemas["ApiDevicePropertyValue"] = this.getComponentsApiDevicePropertyValue();
+      result.components.schemas["DiscoveryResult"] = this.getDiscoveryResultSchema();
 
 
       // デバイスタイプごとのオブジェクト型を追加
@@ -350,6 +353,89 @@ export class RestApiOpenApiConverter{
           }
         }
       }
+    };
+  }
+
+  postDiscoveryRescan = ():OpenAPIV3_1.PathItemObject =>
+  {
+    return {
+      post:{
+        summary:'Rescan ECHONET Lite devices',
+        description:'Run ECHONET Lite discovery again.',
+        tags:[`System`],
+        responses:{
+          '200':{
+            description:'',
+            content:{
+              'application/json':{
+                schema:{$ref:'#/components/schemas/DiscoveryResult'}
+              }
+            }
+          }
+        }
+      }
+    };
+  }
+
+  postDiscoveryRescanIp = ():OpenAPIV3_1.PathItemObject =>
+  {
+    return {
+      post:{
+        summary:'Rescan an ECHONET Lite device by IP address',
+        description:'Run ECHONET Lite discovery for one IP address.',
+        tags:[`System`],
+        parameters:[
+          {
+            name:'ip',
+            description:'Device IP address',
+            in:'path',
+            required:true,
+            schema:{type:'string'}
+          }
+        ],
+        responses:{
+          '200':{
+            description:'',
+            content:{
+              'application/json':{
+                schema:{$ref:'#/components/schemas/DiscoveryResult'}
+              }
+            }
+          },
+          '400':{
+            description:'Invalid IP address',
+            content:{
+              'application/json':{
+                schema:{$ref:'#/components/schemas/DiscoveryResult'}
+              }
+            }
+          },
+          '403':{
+            description:'IP address is outside the ECHONET Lite network',
+            content:{
+              'application/json':{
+                schema:{$ref:'#/components/schemas/DiscoveryResult'}
+              }
+            }
+          }
+        }
+      }
+    };
+  }
+
+  getDiscoveryResultSchema = ():OpenAPIV3_1.NonArraySchemaObject =>
+  {
+    return {
+      type:'object',
+      properties:{
+        status:{type:'string', enum:['completed','busy','error']},
+        reason:{type:'string'},
+        targetIp:{type:'string'},
+        startedAt:{type:'string'},
+        finishedAt:{type:'string'},
+        message:{type:'string'}
+      },
+      required:['status','reason','startedAt','finishedAt']
     };
   }
 

--- a/server/discoveryOptions.ts
+++ b/server/discoveryOptions.ts
@@ -1,0 +1,29 @@
+export const parseDiscoveryStartupRetryIntervals = (value:string):number[]|undefined => {
+  const normalized = value.replace(/^"/g, "").replace(/"$/g, "").trim();
+  if(normalized === "")
+  {
+    return [];
+  }
+
+  const result:number[] = [];
+  for(const text of normalized.split(","))
+  {
+    const interval = Number(text.trim());
+    if(isNaN(interval) || interval < 0)
+    {
+      return undefined;
+    }
+    result.push(interval);
+  }
+  return result;
+};
+
+export const parseDiscoveryPeriodicInterval = (value:string):number|undefined => {
+  const normalized = value.replace(/^"/g, "").replace(/"$/g, "").trim();
+  const interval = Number(normalized);
+  if(normalized === "" || isNaN(interval) || interval < 0)
+  {
+    return undefined;
+  }
+  return interval;
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -12,6 +12,7 @@ import { Logger } from "./Logger";
 import path from "path";
 import os from "os";
 import * as ipaddr from "ipaddr.js";
+import { parseDiscoveryPeriodicInterval, parseDiscoveryStartupRetryIntervals } from "./discoveryOptions";
 
 // Helper function to check if an IP is in a subnet
 function isIpInSubnet(testIp: string, networkIp: string, netmask: string): boolean {
@@ -60,6 +61,8 @@ interface InputParameters{
   echonetDeviceIpList:string;
   echonetDisableAutoDeviceDiscovery:boolean;
   echonetCommandTimeout:number;
+  echonetDiscoveryStartupRetryIntervals:number[];
+  echonetDiscoveryPeriodicInterval:number;
   echonetUserCustomMraFolder:string;
   debugLog:boolean;
   restApiPort:number;
@@ -86,6 +89,8 @@ let echonetUnknownAsError = false;
 let echonetDeviceIpList = "";
 let echonetDisableAutoDeviceDiscovery = false;
 let echonetCommandTimeout = 3000;
+let echonetDiscoveryStartupRetryIntervals = [15, 60];
+let echonetDiscoveryPeriodicInterval = 0;
 let echonetUserCustomMraFolder = "";
 let debugLog = false;
 let restApiPort = 3000;
@@ -164,6 +169,34 @@ if( "ECHONET_COMMAND_TIMEOUT" in process.env &&
   if(isNaN(tempNo)===false)
   {
     echonetCommandTimeout = tempNo;
+  }
+}
+
+if( "ECHONET_DISCOVERY_STARTUP_RETRY_INTERVALS" in process.env &&
+  process.env.ECHONET_DISCOVERY_STARTUP_RETRY_INTERVALS !== undefined)
+{
+  const temp = parseDiscoveryStartupRetryIntervals(process.env.ECHONET_DISCOVERY_STARTUP_RETRY_INTERVALS);
+  if(temp !== undefined)
+  {
+    echonetDiscoveryStartupRetryIntervals = temp;
+  }
+  else
+  {
+    Logger.warn("", `echonetDiscoveryStartupRetryIntervals is invalid format. expected seconds separated by commas. : "${process.env.ECHONET_DISCOVERY_STARTUP_RETRY_INTERVALS}"`)
+  }
+}
+
+if( "ECHONET_DISCOVERY_PERIODIC_INTERVAL" in process.env &&
+  process.env.ECHONET_DISCOVERY_PERIODIC_INTERVAL !== undefined)
+{
+  const temp = parseDiscoveryPeriodicInterval(process.env.ECHONET_DISCOVERY_PERIODIC_INTERVAL);
+  if(temp !== undefined)
+  {
+    echonetDiscoveryPeriodicInterval = temp;
+  }
+  else
+  {
+    Logger.warn("", `echonetDiscoveryPeriodicInterval is invalid format. expected seconds. : "${process.env.ECHONET_DISCOVERY_PERIODIC_INTERVAL}"`)
   }
 }
 
@@ -315,6 +348,22 @@ for(var i = 2;i < process.argv.length; i++){
       echonetCommandTimeout = tempNo;
     }
   }
+  if(name === "--echonetDiscoveryStartupRetryIntervals".toLowerCase())
+  {
+    const temp = parseDiscoveryStartupRetryIntervals(value);
+    if(temp !== undefined)
+    {
+      echonetDiscoveryStartupRetryIntervals = temp;
+    }
+  }
+  if(name === "--echonetDiscoveryPeriodicInterval".toLowerCase())
+  {
+    const temp = parseDiscoveryPeriodicInterval(value);
+    if(temp !== undefined)
+    {
+      echonetDiscoveryPeriodicInterval = temp;
+    }
+  }
   if(name === "--echonetUserCustomMraFolder".toLowerCase())
   {
     echonetUserCustomMraFolder = value.replace(/^"/g, "").replace(/"$/g, "");
@@ -432,6 +481,8 @@ logger.output(`echonetUnknownAsError=${echonetUnknownAsError}`);
 logger.output(`echonetDeviceIpList=${echonetDeviceIpList}`);
 logger.output(`echonetDisableAutoDeviceDiscovery=${echonetDisableAutoDeviceDiscovery}`);
 logger.output(`echonetCommandTimeout=${echonetCommandTimeout}`);
+logger.output(`echonetDiscoveryStartupRetryIntervals=${echonetDiscoveryStartupRetryIntervals.join(",")}`);
+logger.output(`echonetDiscoveryPeriodicInterval=${echonetDiscoveryPeriodicInterval}`);
 logger.output(`echonetUserCustomMraFolder=${echonetUserCustomMraFolder}`);
 logger.output(`debugLog=${debugLog}`);
 logger.output(`restApiPort=${restApiPort}`);
@@ -459,6 +510,8 @@ const inputParameters:InputParameters =
   echonetDeviceIpList,
   echonetDisableAutoDeviceDiscovery,
   echonetCommandTimeout,
+  echonetDiscoveryStartupRetryIntervals,
+  echonetDiscoveryPeriodicInterval,
   echonetUserCustomMraFolder,
   debugLog,
   restApiPort,
@@ -723,7 +776,9 @@ const echoNetListController = new EchoNetLiteController(networkAddressForEchonet
   knownDeviceIpList, echonetDisableAutoDeviceDiscovery===false, echonetCommandTimeout,
   (internalId:string)=>deviceStore.getByInternalId(internalId),
   (ip:string, eoj:string)=>deviceStore.getByIpEoj(ip, eoj),
-  additionalMraFolders);
+  additionalMraFolders,
+  echonetDiscoveryStartupRetryIntervals,
+  echonetDiscoveryPeriodicInterval);
 
 echoNetListController.addDeviceDetectedEvent((device:Device)=>{
   if(device === undefined)
@@ -794,6 +849,32 @@ const detailLogsCallback : ()=>{fileName:string, content:string}[] = ()=>{
   return [{fileName, content}];
 }
 
+const isDiscoveryTargetIpAllowed = (ip:string):boolean => {
+  if(knownDeviceIpList.includes(ip))
+  {
+    return true;
+  }
+
+  if(networkInterfaceForEchonet !== undefined)
+  {
+    return isIpInSubnet(ip, networkInterfaceForEchonet.address, networkInterfaceForEchonet.netmask);
+  }
+
+  const networkInterfaces = os.networkInterfaces();
+  for (const interfaceName of Object.keys(networkInterfaces)) {
+    const interfaces = networkInterfaces[interfaceName];
+    if(interfaces === undefined)
+    {
+      continue;
+    }
+    if(interfaces.filter(_=>_.family === "IPv4").some(_=>isIpInSubnet(ip, _.address, _.netmask)))
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 const restApiController = new RestApiController(
   deviceStore, 
   systemStatusRepository, 
@@ -805,7 +886,8 @@ const restApiController = new RestApiController(
   restApiRoot, 
   mqttBaseTopic, 
   detailLogsCallback,
-  restApiServerSentEventMethod);
+  restApiServerSentEventMethod,
+  isDiscoveryTargetIpAllowed);
 restApiController.addPropertyChangedRequestEvent(async (deviceId:string, propertyName:string, newValue:any):Promise<void>=>{
 
   const device = deviceStore.getFromNameOrId(deviceId);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,6 +1,9 @@
 <div class="container">
   <div class="row">
-    <h2>Devices</h2>
+    <div class="d-flex align-items-center justify-content-between mb-2">
+      <h2 class="mb-0">Devices</h2>
+      <button type="button" id="rescanButton" class="btn btn-primary">Rescan</button>
+    </div>
     <table id="deviceListTable" class="table table-striped" style="min-height:400px">
       <thead>
         <tr>
@@ -41,6 +44,19 @@
       });
     }
     updateSystem();
+
+    $("#rescanButton").on("click", ()=>{
+      const button = $("#rescanButton");
+      button.prop("disabled", true).text("Rescanning...");
+      $.ajax({
+        type: "POST",
+        url: "<%= root %>/api/discovery/rescan",
+        dataType : "json"
+      }).always(()=>{
+        button.prop("disabled", false).text("Rescan");
+        updateSystem();
+      });
+    });
 
     const eventReceiver = new EventReceiver("<%=serverSentEventMethod === 'longpolling' ? 'longpolling' : 'websocket'%>");
     eventReceiver.on("systemUpdated", updateSystem);

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,6 +1,6 @@
 <div class="container">
   <div class="row">
-    <div class="d-flex align-items-center justify-content-between mb-2">
+    <div class="d-flex align-items-center justify-content-between mt-3 mb-3">
       <h2 class="mb-0">Devices</h2>
       <button type="button" id="rescanButton" class="btn btn-primary">Rescan</button>
     </div>


### PR DESCRIPTION
## 概要

起動時の一度だけの ECHONET Lite 探索では、UDP の応答遅延などにより、一部のノードや EOJ が作成されないことがありました。

手元の環境では、SHARP の太陽光発電コントローラーと蓄電池、また複数 EOJ を持つ給湯器系の機器でこの問題が比較的よく発生していました。再起動直後に一部の device が作成されず、もう一度起動し直すか、個別に再探索すると作成される、という状態でした。

## 変更内容

- 起動後の再探索を追加しました（デフォルト: 15秒後、60秒後）
- 手動再探索 API を追加しました
  - `POST /api/discovery/rescan`
  - `POST /api/discovery/rescan/{ip}`
- デバイス一覧画面に `Rescan` ボタンを追加しました
- 未知の EOJ から INF/応答を受けた場合、debounce/cooldown 付きで対象 IP を再探索するようにしました
- property map (`9F`/`9E`/`9D`) の取得を retry するようにしました
- 再探索時に既存の raw node を上書きせず merge し、一時的な取得失敗で既存の device/property が失われないようにしました
- `rescan/{ip}` は ECHONET Lite ネットワーク内の IP のみに制限しました

## 確認

- `npm run build`
- `npm test -- --runInBand`

手元の環境で複数日運用し、起動直後に不足していた device が起動後の再探索で作成されること、および手動再探索で対象 IP の device を再取得できることを確認しています。
